### PR TITLE
Fixes #1 : Remove ddev initialization

### DIFF
--- a/assets/common/web/sites/default/settings.php.append
+++ b/assets/common/web/sites/default/settings.php.append
@@ -23,10 +23,6 @@ if (file_exists($app_root . '/' . $site_path . '/settings.platformsh.php')) {
   include $app_root . '/' . $site_path . '/settings.platformsh.php';
 }
 
-if (file_exists($app_root . '/' . $site_path . '/settings.ddev.php')) {
-  include $app_root . '/' . $site_path . '/settings.ddev.php';
-}
-
 // Local settings. These come last so that they can override anything.
 if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
   include $app_root . '/' . $site_path . '/settings.local.php';


### PR DESCRIPTION
Fixes #1 : Remove ddev initialization, as that's best done by ddev itself and sometimes changes its syntax. Don't assume or provide DDEV support